### PR TITLE
Updated paket.lock file format

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -1,4 +1,4 @@
-RESTRICTION: == net45
+FRAMEWORK: NET45
 NUGET
   remote: https://www.nuget.org/api/v2
     CNTK.CPUOnly (2.2)


### PR DESCRIPTION
_paket restore_ failed with _unknown lock file format RESTRICTION: == net45_ error. Fixed by regeneration .lock file.